### PR TITLE
docs: add Code owners section

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,4 @@ React 18, TypeScript, Vite 7, pnpm, Tailwind CSS …
 pnpm i
 pnpm dev
 
+## Code owners


### PR DESCRIPTION
Adds a ‘Code owners’ section to the README so future contributors know who maintains which area.