### PR TITLE
feat(hotels): infinite scroll & pagination (PAGE_SIZE=4)

### DIFF
--- a/src/pages/HotelList.tsx
+++ b/src/pages/HotelList.tsx
@@ -1,112 +1,151 @@
-// src/pages/HotelList.tsx
-import { useEffect, useState } from 'react';
+/* ────────────────────────────────────────────
+   HotelList.tsx  – infinite scroll, StrictMode-safe
+──────────────────────────────────────────── */
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import { getHotels, type Hotel } from '@/services/hotelService';
 import { formatPrice } from '@/utils/formatPrice';
 import SkeletonCard from '@/components/SkeletonCard';
 
-const DEFAULT_CURRENCY = 'HKD';   // ← change here if you want another default
+const DEFAULT_CURRENCY = 'HKD';
+const PAGE_SIZE        = 4;           // fetch 4 per batch
 
-/* ───────────────────────────────────────────
-   Component
-─────────────────────────────────────────── */
 export default function HotelList() {
+  /* ─── state ─── */
   const [hotels, setHotels]   = useState<Hotel[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError]     = useState<string | null>(null);
+  const [page,   setPage]     = useState(0);          // 0-based page index
+  const [loading, setLoading] = useState(false);
+  const [error,   setError]   = useState<string | null>(null);
+  const [hasMore, setHasMore] = useState(true);
 
-  /* Fetch once on mount */
-  useEffect(() => {
-    const controller = new AbortController();
+  /* refs */
+  const sentinelRef  = useRef<HTMLDivElement | null>(null);
+  const seenPagesRef = useRef<Set<number>>(new Set());     // ← StrictMode guard
+  const obsRef       = useRef<IntersectionObserver | null>(null);
 
-    getHotels()
-      .then(setHotels)
-      .catch(err => {
-        if (!controller.signal.aborted) setError(err.message);
-      })
-      .finally(() => {
-        if (!controller.signal.aborted) setLoading(false);
+  /* ─── fetch helper (safe against double-mount) ─── */
+  const fetchPage = useCallback(async (idx: number) => {
+    if (seenPagesRef.current.has(idx)) return;       // already fetched in this session
+    seenPagesRef.current.add(idx);
+
+    setLoading(true);
+    try {
+      const batch = await getHotels(idx * PAGE_SIZE, PAGE_SIZE);
+
+      /* merge + dedupe by id */
+      setHotels(prev => {
+        const map = new Map<string, Hotel>();
+        prev.forEach(h => map.set(h.id, h));
+        batch.forEach(h => map.set(h.id, h));
+        return Array.from(map.values());
       });
 
-    return () => controller.abort();
+      setHasMore(batch.length === PAGE_SIZE);
+    } catch (err: any) {
+      setError(err.message ?? String(err));
+    } finally {
+      setLoading(false);
+    }
   }, []);
 
-  /* ───── UI ───── */
+  /* first page on mount */
+  useEffect(() => { fetchPage(0); }, [fetchPage]);
+
+  /* fetch next page whenever `page` increments (> 0) */
+  useEffect(() => {
+    if (page > 0) fetchPage(page);
+  }, [page, fetchPage]);
+
+  /* ─── IntersectionObserver for infinite scroll ─── */
+  useEffect(() => {
+    if (!hasMore) return;
+    const el = sentinelRef.current;
+    if (!el) return;
+
+    /* clean up previous observer (hot reload etc.) */
+    obsRef.current?.disconnect();
+    obsRef.current = new IntersectionObserver(
+      entries => {
+        if (entries[0].isIntersecting && !loading) {
+          setPage(p => p + 1);
+        }
+      },
+      { rootMargin: '200px' }           // pre-fetch a bit before the bottom
+    );
+    obsRef.current.observe(el);
+    return () => obsRef.current?.disconnect();
+  }, [hasMore, loading]);
+
+  /* ─── UI ─── */
   return (
     <main className="mx-auto px-4 py-8">
       <h1 className="text-3xl font-bold mb-6">Available Hotels</h1>
 
-      {/* Error state */}
-      {error && (
-        <p className="text-center mt-10 text-red-600" role="alert">
-          {error}
-        </p>
-      )}
+      {error && <p className="text-center text-red-600">{error}</p>}
 
-      {/* Empty-result state */}
-      {!loading && hotels.length === 0 && !error && <p>No hotels found.</p>}
+      <div
+        className="
+          grid gap-6 justify-items-center
+          sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5
+        "
+      >
+        {hotels.map(hotel => {
+          /* keep backward-compat with old `price` field */
+          const nightly =
+            (hotel as any).pricePerNight ?? (hotel as any).price ?? null;
 
-      {/* Skeletons OR real cards */}
-      {(loading || hotels.length > 0) && (
-        <div
-          className="
-            grid gap-6 justify-items-center
-            sm:grid-cols-2
-            lg:grid-cols-3
-            xl:grid-cols-4
-            2xl:grid-cols-5
-          "
-        >
-          {loading
-            ? Array.from({ length: 8 }).map((_, i) => (
-                <SkeletonCard key={i} />
-              ))
-            : hotels.map(hotel => (
-                <article
-                  key={hotel.id}
-                  className="
-                    rounded-2xl shadow hover:shadow-lg transition p-4
-                    flex flex-col bg-white
-                  "
-                >
-                  <img
-                    src={hotel.imageUrl ?? '/placeholder.jpg'}
-                    alt={hotel.name}
-                    className="h-40 w-full object-cover rounded-xl mb-4"
-                    loading="lazy"
-                  />
+          return (
+            <article
+              key={hotel.id}
+              className="
+                rounded-2xl shadow hover:shadow-lg transition p-4
+                flex flex-col bg-white
+              "
+            >
+              <img
+                src={hotel.imageUrl ?? '/placeholder.jpg'}
+                alt={hotel.name}
+                className="h-40 w-full object-cover rounded-xl mb-4"
+                loading="lazy"
+              />
 
-                  <h2 className="text-xl font-semibold mb-1 truncate">
-                    {hotel.name}
-                  </h2>
-                  <p className="text-sm text-gray-600 flex-1">
-                    {hotel.city}
-                  </p>
+              <h2 className="text-xl font-semibold mb-1 truncate">
+                {hotel.name}
+              </h2>
+              <p className="text-sm text-gray-600 flex-1">{hotel.city}</p>
 
-                  <p className="mt-2 font-medium">
-                    {hotel.price != null ? (
-                      <>
-                        {formatPrice(hotel.price, DEFAULT_CURRENCY)}
-                        <span className="text-sm font-normal"> / night</span>
-                      </>
-                    ) : (
-                      <span className="italic text-gray-500">
-                        Price on request
-                      </span>
-                    )}
-                  </p>
+              <p className="mt-2 font-medium">
+                {nightly != null ? (
+                  <>
+                    {formatPrice(nightly, DEFAULT_CURRENCY)}
+                    <span className="text-sm font-normal"> / night</span>
+                  </>
+                ) : (
+                  <span className="italic text-gray-500">Price on request</span>
+                )}
+              </p>
 
-                  <Link
-                    to={`/hotels/${hotel.id}`}
-                    className="mt-4 inline-block text-blue-600 underline self-start"
-                  >
-                    View details →
-                  </Link>
-                </article>
-              ))}
-        </div>
-      )}
+              <Link
+                to={`/hotels/${hotel.id}`}
+                className="mt-4 inline-block text-blue-600 underline self-start"
+              >
+                View details →
+              </Link>
+            </article>
+          );
+        })}
+
+        {/* skeletons while loading next page */}
+        {loading &&
+          Array.from({ length: PAGE_SIZE }).map((_, i) => (
+            <SkeletonCard key={`skeleton-${i}`} />
+          ))}
+      </div>
+
+      {/* sentinel for IntersectionObserver */}
+      {hasMore && <div ref={sentinelRef} className="h-20" />}
     </main>
   );
 }
+

--- a/src/services/hotelService.ts
+++ b/src/services/hotelService.ts
@@ -5,37 +5,58 @@ import { api } from '@/utils/api';
    Domain model
 ─────────────────────────────────────────────── */
 export interface Hotel {
-  id:       string;
-  name:     string;
-  city:     string;
-  price:    number;          // nightly price (HKD)
-  imageUrl?: string | null;
+  id:             string;
+  name:           string;
+  city:           string;
+  /** preferred field – nightly rate in HKD (or chosen currency) */
+  pricePerNight:  number | null;
+  /** legacy seed field kept for backward-compat */
+  price?:         number | null;
+  imageUrl?:      string | null;
+}
+
+/* ───────────────────────────────────────────────
+   Helper: coerce any raw object to our Hotel shape
+─────────────────────────────────────────────── */
+function toHotel(obj: any): Hotel {
+  return {
+    id:            obj.id,
+    name:          obj.name,
+    city:          obj.city,
+    pricePerNight: obj.pricePerNight ?? obj.price ?? null,
+    price:         obj.price,        // keep if callers still reference it
+    imageUrl:      obj.imageUrl ?? null,
+  };
 }
 
 /* ───────────────────────────────────────────────
    Data fetch + normaliser
 ─────────────────────────────────────────────── */
 /**
- * GET /hotels
- * Always resolves to a plain Hotel[] no matter how the backend wraps it.
- * Logs the raw payload so you can inspect it in DevTools → Console.
+ * GET /hotels?skip=&take=
+ * • Always resolves to a plain `Hotel[]`.
+ * • `skip` / `take` enable infinite scroll pagination.
+ * • Logs the raw payload for easy inspection in DevTools.
  */
-export async function getHotels(): Promise<Hotel[]> {
-  const raw = await api<any>('/hotels');
-  console.log('🛬 /hotels raw payload', raw);        // DEBUG: check console
+export async function getHotels(
+  skip: number = 0,
+  take: number = 20
+): Promise<Hotel[]> {
+  const raw = await api<any>('/hotels', { params: { skip, take } });
+  console.log('🛬 /hotels raw payload', raw);          // DEBUG
 
   /* 1️⃣  Plain array */
-  if (Array.isArray(raw)) return raw;
+  if (Array.isArray(raw)) return raw.map(toHotel);
 
   /* 2️⃣  Common wrappers */
-  if (Array.isArray(raw.hotels)) return raw.hotels;   // { hotels: [...] }
-  if (Array.isArray(raw.data))   return raw.data;     // { data: [...] }
-  if (Array.isArray(raw.result)) return raw.result;   // { result: [...] }
+  if (Array.isArray(raw.hotels)) return raw.hotels.map(toHotel);
+  if (Array.isArray(raw.data))   return raw.data.map(toHotel);
+  if (Array.isArray(raw.result)) return raw.result.map(toHotel);
 
-  /* 3️⃣  Empty but valid response */
+  /* 3️⃣  Empty-but-valid object → pick first array-like property */
   if (raw && typeof raw === 'object') {
     const firstArray = Object.values(raw).find(Array.isArray);
-    if (Array.isArray(firstArray)) return firstArray as Hotel[];
+    if (Array.isArray(firstArray)) return (firstArray as any[]).map(toHotel);
   }
 
   /* 4️⃣  Anything else → treat as error */


### PR DESCRIPTION
### ✨ What’s new
- Added **IntersectionObserver**-based infinite scroll to **HotelList**
- Introduced `PAGE_SIZE = 4` server-side pagination via `getHotels(skip, take)`
- De-dupe results by `id` to avoid React key warnings

### 🔍 How to test
1. `pnpm dev` (API + SPA)  
2. Scroll to the bottom → next 4 hotels load  
3. No duplicate cards & network tab shows `skip=4`, `skip=8`, …

### 📌 Related
Fixes #123 (slow initial load)
